### PR TITLE
Move player model into object

### DIFF
--- a/src/main/scala/org/thomlink/tictactoe/TicTacToeService.scala
+++ b/src/main/scala/org/thomlink/tictactoe/TicTacToeService.scala
@@ -1,6 +1,6 @@
 package org.thomlink.tictactoe
 
-import org.thomlink.tictactoe.model.{Board, Draw, Free, GameResult, Incomplete, O, Occupied, Player, PositionState, Winner, X}
+import org.thomlink.tictactoe.model.{Board, Draw, Free, GameResult, Incomplete, Occupied, Player, PositionState, Winner}
 
 
 
@@ -12,9 +12,6 @@ case class IncorrectMoveCount(description: String) extends InvalidBoardError
 
 
 object TicTacToeService {
-
-  //  sealed trait BoardError extends Throwable
-  //  case class InvalidBoard(description: String) extends BoardError
 
   private def resultOfThreeTiles(a: PositionState, b: PositionState, c: PositionState): Option[Player] =
     if (a == b && b == c) {
@@ -68,8 +65,8 @@ object TicTacToeService {
    */
   private def moveCountDiff(board: Board): Int = {
     val positions = board.toList
-    val xMoves = positions.count(_ == Occupied(X))
-    val oMoves = positions.count(_ == Occupied(O))
+    val xMoves = positions.count(_ == Occupied(Player.X))
+    val oMoves = positions.count(_ == Occupied(Player.O))
     xMoves - oMoves
   }
 
@@ -111,16 +108,16 @@ object TicTacToeService {
       allPossibleWinners(board).flatten match {
         case winner :: Nil =>
           winner match {
-            case model.X =>
+            case Player.X =>
               moveDifference match {
-                case 1 => Right(Winner(X))
+                case 1 => Right(Winner(Player.X))
                 case x if x > 1 => Left(IncorrectMoveCount("foo"))
                 case _ => Left(MovedAfterLoss("O moved after losing"))
               }
 
-            case model.O =>
+            case Player.O =>
               moveDifference match {
-                case 0 => Right(Winner(O))
+                case 0 => Right(Winner(Player.O))
                 case x if x < 0 => Left(IncorrectMoveCount("foo"))
                 case _ => Left(MovedAfterLoss("X moved after losing"))
               }

--- a/src/main/scala/org/thomlink/tictactoe/model/package.scala
+++ b/src/main/scala/org/thomlink/tictactoe/model/package.scala
@@ -9,9 +9,10 @@ package object model {
 
 
   sealed trait Player
-  case object X extends Player
-  case object O extends Player
-
+  object Player {
+    case object X extends Player
+    case object O extends Player
+  }
   sealed trait PositionState
   case class Occupied(player: Player) extends PositionState
   case object Free extends PositionState

--- a/src/test/scala/org/thomlink/tictactoe/TestData.scala
+++ b/src/test/scala/org/thomlink/tictactoe/TestData.scala
@@ -2,48 +2,48 @@ package org.thomlink.tictactoe
 
 import cats.Show
 import org.scalacheck.Gen
-import org.thomlink.tictactoe.model.{Board, Free, O, Occupied, Player, X}
+import org.thomlink.tictactoe.model.{Board, Free, Occupied, Player}
 
 object TestData {
 
   def topRowWinner(winner: Player): Board = {
     winner match {
-      case model.X => Board(
-        a1 = Occupied(X), b1 = Occupied(X), c1 = Occupied(X), a2 = Occupied(O), b2 = Free, c2 = Occupied(O), a3 = Free, b3 = Free, c3 = Free
+      case Player.X => Board(
+        a1 = Occupied(Player.X), b1 = Occupied(Player.X), c1 = Occupied(Player.X), a2 = Occupied(Player.O), b2 = Free, c2 = Occupied(Player.O), a3 = Free, b3 = Free, c3 = Free
       )
-      case model.O => Board(
-        a1 = Occupied(O), b1 = Occupied(O), c1 = Occupied(O), a2 = Occupied(X), b2 = Free, c2 = Occupied(X), a3 = Occupied(X), b3 = Free, c3 = Free
+      case Player.O => Board(
+        a1 = Occupied(Player.O), b1 = Occupied(Player.O), c1 = Occupied(Player.O), a2 = Occupied(Player.X), b2 = Free, c2 = Occupied(Player.X), a3 = Occupied(Player.X), b3 = Free, c3 = Free
       )
     }
   }
 
   def middleRowWinner(winner: Player): Board = {
     winner match {
-      case model.X => Board(
-        a1 = Free, b1 = Free, c1 = Occupied(O), a2 = Occupied(X), b2 = Occupied(X), c2 = Occupied(X), a3 = Occupied(O), b3 = Free, c3 = Free
+      case Player.X => Board(
+        a1 = Free, b1 = Free, c1 = Occupied(Player.O), a2 = Occupied(Player.X), b2 = Occupied(Player.X), c2 = Occupied(Player.X), a3 = Occupied(Player.O), b3 = Free, c3 = Free
       )
-      case model.O => Board(
-        a1 = Occupied(O), b1 = Occupied(O), c1 = Occupied(O), a2 = Occupied(X), b2 = Free, c2 = Occupied(X), a3 = Occupied(X), b3 = Free, c3 = Free
+      case Player.O => Board(
+        a1 = Occupied(Player.O), b1 = Occupied(Player.O), c1 = Occupied(Player.O), a2 = Occupied(Player.X), b2 = Free, c2 = Occupied(Player.X), a3 = Occupied(Player.X), b3 = Free, c3 = Free
       )
     }
   }
 
   def bottomRowWinner(winner: Player): Board = {
     winner match {
-      case model.X => Board(
-        a1 = Free, b1 = Free, c1 = Free, a2 = Free, b2 = Occupied(O), c2 = Occupied(O), a3 = Occupied(X), b3 = Occupied(X), c3 = Occupied(X)
+      case Player.X => Board(
+        a1 = Free, b1 = Free, c1 = Free, a2 = Free, b2 = Occupied(Player.O), c2 = Occupied(Player.O), a3 = Occupied(Player.X), b3 = Occupied(Player.X), c3 = Occupied(Player.X)
       )
-      case model.O => Board(
-        a1 = Free, b1 = Free, c1 = Occupied(X), a2 = Free, b2 = Occupied(X), c2 = Occupied(X), a3 = Occupied(O), b3 = Occupied(O), c3 = Occupied(O))
+      case Player.O => Board(
+        a1 = Free, b1 = Free, c1 = Occupied(Player.X), a2 = Free, b2 = Occupied(Player.X), c2 = Occupied(Player.X), a3 = Occupied(Player.O), b3 = Occupied(Player.O), c3 = Occupied(Player.O))
     }
   }
 
   def upwardDiagonalWinner(player: model.Player): Board = player match {
-    case model.X => Board(
-      a1 = Occupied(X), b1 = Free, c1 = Free, a2 = Free, b2 = Occupied(X), c2 = Occupied(O), a3 = Occupied(O), b3 = Free, c3 = Occupied(X)
+    case Player.X => Board(
+      a1 = Occupied(Player.X), b1 = Free, c1 = Free, a2 = Free, b2 = Occupied(Player.X), c2 = Occupied(Player.O), a3 = Occupied(Player.O), b3 = Free, c3 = Occupied(Player.X)
     )
-    case model.O => Board(
-      a1 = Occupied(O), b1 = Occupied(X), c1 = Free, a2 = Free, b2 = Occupied(O), c2 = Occupied(X), a3 = Occupied(X), b3 = Free, c3 = Occupied(O)
+    case Player.O => Board(
+      a1 = Occupied(Player.O), b1 = Occupied(Player.X), c1 = Free, a2 = Free, b2 = Occupied(Player.O), c2 = Occupied(Player.X), a3 = Occupied(Player.X), b3 = Free, c3 = Occupied(Player.O)
     )
   }
 
@@ -81,37 +81,37 @@ object TestData {
   //OOX  XOO  XOO  OOX
   //XXO  OXX  XOX  XOX
   val drawGame: Board = Board(
-    a1 = Occupied(X), b1 = Occupied(O), c1 = Occupied(X), a2 = Occupied(O), b2 = Occupied(O), c2 = Occupied(X), a3 = Occupied(X), b3 = Occupied(X), c3 = Occupied(O)
+    a1 = Occupied(Player.X), b1 = Occupied(Player.O), c1 = Occupied(Player.X), a2 = Occupied(Player.O), b2 = Occupied(Player.O), c2 = Occupied(Player.X), a3 = Occupied(Player.X), b3 = Occupied(Player.X), c3 = Occupied(Player.O)
   )
 
   val incompleteGame: Board = Board(
-    a1 = Occupied(X), b1 = Occupied(O), c1 = Occupied(X), a2 = Occupied(O), b2 = Occupied(O), c2 = Occupied(X), a3 = Occupied(X), b3 = Free, c3 = Free
+    a1 = Occupied(Player.X), b1 = Occupied(Player.O), c1 = Occupied(Player.X), a2 = Occupied(Player.O), b2 = Occupied(Player.O), c2 = Occupied(Player.X), a3 = Occupied(Player.X), b3 = Free, c3 = Free
   )
 
   val incompleteGame2: Board = Board(
-    a1 = Occupied(X), b1 = Occupied(O), c1 = Occupied(X), a2 = Free, b2 = Free, c2 = Free, a3 = Free, b3 = Free, c3 = Free
+    a1 = Occupied(Player.X), b1 = Occupied(Player.O), c1 = Occupied(Player.X), a2 = Free, b2 = Free, c2 = Free, a3 = Free, b3 = Free, c3 = Free
   )
   //---
 
   val multipleWinners: Board = Board(
-    a1 = Occupied(X), b1 = Occupied(X), c1 = Occupied(X), a2 = Occupied(O), b2 = Occupied(O), c2 = Occupied(O), a3 = Free, b3 = Free, c3 = Free
+    a1 = Occupied(Player.X), b1 = Occupied(Player.X), c1 = Occupied(Player.X), a2 = Occupied(Player.O), b2 = Occupied(Player.O), c2 = Occupied(Player.O), a3 = Free, b3 = Free, c3 = Free
   )
 
 
   val invalidBoardXs: Board = Board(
-    a1 = Occupied(X), b1 = Occupied(X), c1 = Occupied(X), a2 = Occupied(O), b2 = Free, c2 = Free, a3 = Free, b3 = Free, c3 = Free
+    a1 = Occupied(Player.X), b1 = Occupied(Player.X), c1 = Occupied(Player.X), a2 = Occupied(Player.O), b2 = Free, c2 = Free, a3 = Free, b3 = Free, c3 = Free
   )
 
   val invalidBoardOs: Board = Board(
-    a1 = Occupied(O), b1 = Occupied(O), c1 = Occupied(X), a2 = Occupied(O), b2 = Free, c2 = Free, a3 = Free, b3 = Free, c3 = Free
+    a1 = Occupied(Player.O), b1 = Occupied(Player.O), c1 = Occupied(Player.X), a2 = Occupied(Player.O), b2 = Free, c2 = Free, a3 = Free, b3 = Free, c3 = Free
   )
 
   val invalidBoardOMovesAfterLoss: Board = Board(
-    a1 = Occupied(X), b1 = Occupied(X), c1 = Occupied(X), a2 = Occupied(O), b2 = Occupied(O), c2 = Free, a3 = Occupied(O), b3 = Free, c3 = Free
+    a1 = Occupied(Player.X), b1 = Occupied(Player.X), c1 = Occupied(Player.X), a2 = Occupied(Player.O), b2 = Occupied(Player.O), c2 = Free, a3 = Occupied(Player.O), b3 = Free, c3 = Free
   )
 
   val invalidBoardXMovesAfterLoss: Board = Board(
-    a1 = Occupied(X), b1 = Occupied(X), c1 = Occupied(O), a2 = Occupied(X), b2 = Occupied(X), c2 = Occupied(O), a3 = Free, b3 = Free, c3 = Occupied(O)
+    a1 = Occupied(Player.X), b1 = Occupied(Player.X), c1 = Occupied(Player.O), a2 = Occupied(Player.X), b2 = Occupied(Player.X), c2 = Occupied(Player.O), a3 = Free, b3 = Free, c3 = Occupied(Player.O)
   )
 
   val unbalancedMovesGen = Gen.oneOf(

--- a/src/test/scala/org/thomlink/tictactoe/TicTacToeServiceTest.scala
+++ b/src/test/scala/org/thomlink/tictactoe/TicTacToeServiceTest.scala
@@ -32,9 +32,9 @@ object TicTacToeServiceTest extends weaver.SimpleIOSuite  with Checkers{
       |in all cases where X should win
       |""".stripMargin
   ) {
-    forall(winningBoardGen(X)) { board =>
+    forall(winningBoardGen(Player.X)) { board =>
       val result = TicTacToeService.gameResult(board)
-      expect(result == Right(Winner(X)))
+      expect(result == Right(Winner(Player.X)))
     }
   }
 
@@ -45,9 +45,9 @@ object TicTacToeServiceTest extends weaver.SimpleIOSuite  with Checkers{
       |in all cases where O should win
       |""".stripMargin
   ) {
-    forall(winningBoardGen(O)) { board =>
+    forall(winningBoardGen(Player.O)) { board =>
       val result = TicTacToeService.gameResult(board)
-      expect(result == Right(Winner(O)))
+      expect(result == Right(Winner(Player.O)))
     }
   }
 


### PR DESCRIPTION
To remove the random `X`s and `O`s lying around, we moved them into a Player object, so that they should be summoned via `Player.X`, to improve readability